### PR TITLE
Fix defunct dfm and tokens usages

### DIFF
--- a/R/q_dtm.R
+++ b/R/q_dtm.R
@@ -61,7 +61,9 @@ q_dtm <- function(text, docs = seq_along(text), to = "tm", keep.hyphen = FALSE,
         docs <- sort(unique(docs))
     }
 
-    out <- quanteda::convert(quanteda::dfm(text, stem = FALSE, verbose = FALSE, remove_numbers = FALSE, ...), to = to)
+    input <- quanteda::tokens(text, remove_numbers = FALSE, verbose = FALSE, ...) |>
+        quanteda::dfm()
+    out <- quanteda::convert(input, to = to)
     row.names(out) <- docs
     if (!is.null(ngrams))colnames(out) <- gsub('gofastrseparatorgofastr', ' ', colnames(out))
 
@@ -100,7 +102,11 @@ q_dtm_stem <- function(text, docs = seq_along(text), to = "tm", keep.hyphen = FA
         docs <- sort(unique(docs))
     }
 
-    out <- quanteda::convert(quanteda::dfm(text, stem = TRUE, verbose = FALSE, remove_numbers = FALSE, ...), to = to)
+    input <- quanteda::tokens(text, remove_numbers = FALSE, verbose = FALSE, ...) |>
+        quanteda::tokens_wordstem() |>
+        quanteda::dfm()
+    out <- quanteda::convert(input, to = to)
+    
     row.names(out) <- docs
     if (!is.null(ngrams))colnames(out) <- gsub('gofastrseparatorgofastr', ' ', colnames(out))
 


### PR DESCRIPTION
These fixes will ensure that your package does not break when we publish **quanteda** v4.

Breaking changes:
* `dfm.character()` is deprecated in v3 and defunct in v4
* `stem` is no longer an argument for `tokens()` or `dfm()`

Note also that `dfm()` in **quanteda** v4 is also faster by up to  30% as we re-implemented it in C++.